### PR TITLE
Move furniture from other mods away from AOMorefurniture designationCategory

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -75,5 +75,8 @@
     <li IfModActive="finch.blood">Mods and Shit/Rimfantasy Sanguine</li>
     <li IfModActive="addie.housevanilla">Mods and Shit/Rimfantasy Vanilla</li>
     <li IfModActive="sierra.rf.housedoyle">Mods and Shit/Rimfantasy Doyle</li>
+    <li IfModActive="cixwow.vfespaceraddon">Mods and Shit/VFE Spacer Addon</li>
+    <li IfModActive="lmgginspace.repairbed">Mods and Shit/Repair Bed</li>
+    <li IfModActive="farxmai2.vanillafurnitureexpandedpack">Mods and Shit/VE Furniture Additional Pack</li>
   </v1.5>
 </loadFolders>

--- a/Mods and Shit/Repair Bed/Patches/repair bed.xml
+++ b/Mods and Shit/Repair Bed/Patches/repair bed.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="LMGG_Thing_RepairBed"]/designationCategory</xpath>
+    <value>
+      <designationCategory>Furniture</designationCategory>
+    </value>
+  </Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="LMGG_Thing_RepairDoubleBed"]/designationCategory</xpath>
+    <value>
+      <designationCategory>Furniture</designationCategory>
+    </value>
+  </Operation>
+</Patch>

--- a/Mods and Shit/VE Furniture Additional Pack/Patches/royal sofa.xml
+++ b/Mods and Shit/VE Furniture Additional Pack/Patches/royal sofa.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="FFE_RoyalSofa"]/designationCategory</xpath>
+    <value>
+      <designationCategory>Furniture</designationCategory>
+    </value>
+  </Operation>
+</Patch>

--- a/Mods and Shit/VFE Spacer Addon/Patches/extra interactive tables.xml
+++ b/Mods and Shit/VFE Spacer Addon/Patches/extra interactive tables.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Table_interactive_1x2c"]/designationCategory</xpath>
+    <value>
+      <designationCategory>Furniture</designationCategory>
+    </value>
+  </Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Table_interactive_3x3c"]/designationCategory</xpath>
+    <value>
+      <designationCategory>Furniture</designationCategory>
+    </value>
+  </Operation>
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Table_interactive_2x4c"]/designationCategory</xpath>
+    <value>
+      <designationCategory>Furniture</designationCategory>
+    </value>
+  </Operation>
+</Patch>


### PR DESCRIPTION
This is to add support into Progression: Aesthetics for mods which aren't part of the ferny modpack. 
- [[lmgginspace] Repair bed](https://steamcommunity.com/sharedfiles/filedetails/?id=2656590581)
- [Vanilla Furniture Expanded Pack](https://steamcommunity.com/sharedfiles/filedetails/?id=2915484451)
- [VFE Spacer Addon](https://steamcommunity.com/sharedfiles/filedetails/?id=2816486181)

### Mod Integrations:

* Added three new mods to the `LoadFolders.xml` file: `VFE Spacer Addon`, `Repair Bed`, and `VE Furniture Additional Pack`. These entries ensure the patches are properly loaded if their respective dependencies are active.

### XML Patch Updates:

* [`Mods and Shit/Repair Bed/Patches/repair bed.xml`](diffhunk://#diff-83f2b140144928f2a7528e02cdc6ad964755ce1348ed7bd97e80a2599cdd6f44R1-R15): Added a patch to update the `designationCategory` of the `RepairBed` and `RepairDoubleBed` items to `Furniture`.
* [`Mods and Shit/VE Furniture Additional Pack/Patches/royal sofa.xml`](diffhunk://#diff-0ff088b6a047a0eeefe22033fdb7379a3e8478d185dd7d966105869233445ca6R1-R9): Added a patch to change the `designationCategory` of the `RoyalSofa` item to `Furniture`.
* [`Mods and Shit/VFE Spacer Addon/Patches/extra interactive tables.xml`](diffhunk://#diff-b80f4e776d007ce2703ecaf8afcb0fa777de077816076338ee138042911f0c91R1-R21): Added a patch to modify the `designationCategory` of three interactive table items (`Table_interactive_1x2c`, `Table_interactive_3x3c`, and `Table_interactive_2x4c`) to `Furniture`