### PR TITLE
Remove duplicate designatorDropdown patch

### DIFF
--- a/Mods and Shit/AP Parks/Patches/apparks_patch.xml
+++ b/Mods and Shit/AP Parks/Patches/apparks_patch.xml
@@ -38,13 +38,6 @@
 </Operation>
 <Operation Class="PatchOperationAdd">
     <success>Always</success>
-    <xpath>Defs/ThingDef[defName="VFEPD_AP_LamplightA_Functional"]</xpath>
-    <value>
-        <designatorDropdown>Ferny_StreetLamps</designatorDropdown>
-    </value>
-</Operation>
-<Operation Class="PatchOperationAdd">
-    <success>Always</success>
     <xpath>Defs/ThingDef[defName="VFEPD_AP_LamplightB_Functional"]</xpath>
     <value>
         <designatorDropdown>Ferny_StreetLamps</designatorDropdown>


### PR DESCRIPTION
This pull request removes an unnecessary `PatchOperationAdd` block from the `apparks_patch.xml` file to clean up the configuration.

Code cleanup:

* [`Mods and Shit/AP Parks/Patches/apparks_patch.xml`](diffhunk://#diff-4570f0cd02e4a69d42ccde91d6d569934e7e2175bbddc4c669141d2d9bd3e6c9L39-L45): Removed a redundant `PatchOperationAdd` block targeting `VFEPD_AP_LamplightA_Functional` to prevent an error being thrown.