### PR TITLE
Refactor for VE Furniture update

### DIFF
--- a/Mods and Shit/Medieval Overhaul/Patches/medieval overhual patch.xml
+++ b/Mods and Shit/Medieval Overhaul/Patches/medieval overhual patch.xml
@@ -1,827 +1,1236 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <Patch>
-
-
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ResearchProjectDef[defName="DankPyon_RusticFurniture"]/label</xpath>
-                    <value>
-                        <label>Medieval furniture</label>
-                    </value>
-                </Operation>
-
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Closed1x2c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_DividerColumn"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Open1x2c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-
-<!-- SIGNS INTEGRATION -->
-
-
-
-<Operation Class="PatchOperationFindMod">
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ResearchProjectDef[defName="DankPyon_RusticFurniture"]/label</xpath>
+		<value>
+			<label>Medieval furniture</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Closed1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Closed1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Closed1x2c"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_DividerColumn"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_DividerColumn"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_DividerColumn"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Open1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Open1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticThickRoomDivider_Open1x2c"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<!-- SIGNS INTEGRATION -->
+	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Signs and Comments</li>
 		</mods>
 		<match Class="PatchOperationSequence">
-    <operations>
-
-      <li Class="PatchOperationAdd">
-        <success>Always</success>
-        <xpath>/Defs/ThingDef[@Name="BDsSignBase"]</xpath>
-        <value>
-          <drawGUIOverlay>true</drawGUIOverlay>
-        </value>
-      </li>
-
-      <li Class="PatchOperationReplace">
-        <success>Always</success>
-        <xpath>Defs/ThingDef[@Name="DankPyon_SignBase"]/designationCategory</xpath>
-        <value>
-          <designationCategory>Dark_Signs</designationCategory>
-        </value>
-      </li>
-
-      <li Class="PatchOperationConditional">
-        <xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/comps</xpath>
-        <nomatch Class="PatchOperationAdd">
-          <xpath>/Defs/ThingDef[@Name="BDsSignBase"]</xpath>
-          <value>
-            <comps>
-              <li Class="Dark.Signs.CompProperties_Sign">
-                <canEditContent>true</canEditContent>
-                <canBeEmpty>true</canBeEmpty>
-                <defaultContents></defaultContents>
-              </li>
-            </comps>
-          </value>
-        </nomatch>
-        <match Class="PatchOperationAdd">
-          <success>Always</success>
-          <xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/comps</xpath>
-          <value>
-            <li Class="Dark.Signs.CompProperties_Sign">
-              <canEditContent>true</canEditContent>
-              <canBeEmpty>true</canBeEmpty>
-              <defaultContents></defaultContents>
-            </li>
-          </value>
-        </match>
-      </li>
-
-      <li Class="PatchOperationAdd">
-        <success>Always</success>
-        <xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]</xpath>
-        <value>
-          <drawGUIOverlay>true</drawGUIOverlay>
-        </value>
-      </li>
-    </operations>
+			<operations>
+				<li Class="PatchOperationAdd">
+					<success>Always</success>
+					<xpath>/Defs/ThingDef[@Name="BDsSignBase"]</xpath>
+					<value>
+						<drawGUIOverlay>true</drawGUIOverlay>
+					</value>
+				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/designationCategory</xpath>
+					<match Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/designationCategory</xpath>
+						<value>
+							<designationCategory>Dark_Signs</designationCategory>
+						</value>
+					</match>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]</xpath>
+						<value>
+							<designationCategory>Dark_Signs</designationCategory>
+						</value>
+					</nomatch>
+				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/comps</xpath>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[@Name="BDsSignBase"]</xpath>
+						<value>
+							<comps>
+								<li Class="Dark.Signs.CompProperties_Sign">
+									<canEditContent>true</canEditContent>
+									<canBeEmpty>true</canBeEmpty>
+									<defaultContents/>
+								</li>
+							</comps>
+						</value>
+					</nomatch>
+					<match Class="PatchOperationAdd">
+						<success>Always</success>
+						<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/comps</xpath>
+						<value>
+							<li Class="Dark.Signs.CompProperties_Sign">
+								<canEditContent>true</canEditContent>
+								<canBeEmpty>true</canBeEmpty>
+								<defaultContents/>
+							</li>
+						</value>
+					</match>
+				</li>
+				<li Class="PatchOperationAdd">
+					<success>Always</success>
+					<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]</xpath>
+					<value>
+						<drawGUIOverlay>true</drawGUIOverlay>
+					</value>
+				</li>
+			</operations>
 		</match>
 	</Operation>
-
-
-
-
-
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="BasicBedBase"]</xpath>
-                    <value>
-                        <costList>
-                          <Cloth>40</Cloth>
-                        </costList>
-                    </value>
-                </Operation>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- REORGANIZE AND HIDE -->
-                <Operation Class="PatchOperationReplace">
-                  <success>Always</success>
-                  <xpath>Defs/ThingDef[defName="DankPyon_RusticDresser"]/designationCategory</xpath>
-                  <value>
-                        <designationCategory></designationCategory>
-                  </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                  <success>Always</success>
-                  <xpath>Defs/ThingDef[defName="DankPyon_RusticDresser"]/designationCategory</xpath>
-                  <value>
-                        <designationCategory></designationCategory>
-                  </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                  <success>Always</success>
-                  <xpath>Defs/ThingDef[defName="DankPyon_RusticDoor"]</xpath>
-                  <value>
-                        <designationCategory></designationCategory>
-                  </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                  <success>Always</success>
-                  <xpath>Defs/ThingDef[@Name="DankPyon_SignBase"]/designationCategory</xpath>
-                  <value>
-                        <designationCategory>Misc</designationCategory>
-                  </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                  <success>Always</success>
-                  <xpath>Defs/ThingDef[defName="DankPyon_BarrelWater"]/designationCategory</xpath>
-                  <value>
-                        <designationCategory>Misc</designationCategory>
-                  </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_BannerBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticRoomDivider1x2c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticTable1x1c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x1c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticTable1x2c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x2c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticTable2x2c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable2x2c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Table2x4c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_ReinforcedTable2x4c"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticChair"]</xpath>
-                      <value>
-                          <designationCategory></designationCategory>
-                      </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_TableGatherSpotBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_BedWithQualityBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_BasicBedBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]/label</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]/label</xpath>
-                    <value>
-                        <label>royal research shelf</label>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticBookshelf"]/label</xpath>
-                    <value>
-                        <label>research shelf</label>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_ArtableBedBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Lecturn"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticBookshelf"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticBookshelf1x2c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticBookshelf1x2c"]/label</xpath>
-                    <value>
-                        <label>large research shelf</label>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RoyalCloset"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticCloset"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticCloset"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticCloset1x2c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticTallEndTable"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticEndTable"]</xpath>
-                    <value>
-                        <designationCategory></designationCategory>
-                    </value>
-                </Operation>
-
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="VFEV_DoubleFurBed"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RoyalTudorBed"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_WoodBurningStove"]</xpath>
-                    <value>
-                        <designationCategory>Temperature</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticHearth"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Temperature</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_MarketTent_1c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_FurnitureWithQualityBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticChest"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_MetalStrongbox"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RoyalChest"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_WallTorch"]</xpath>
-                    <value>
-                        <designationCategory></designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_WallLamp"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_LampPost"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_CandleStand"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_CandleStand_Beeswax"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticLamp"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticTorchLamp"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>/Defs/ThingDef[@Name="DankPyon_BuildingBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_TableBase"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticEmptyShelf1x2c"]</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticEmptyShelf"]</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticStool"]</xpath>
-                    <value>
-                        <designationCategory></designationCategory>
-                    </value>
-                </Operation>
-
-
-
-
-
-<!-- RENAME SHIT -->
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Bed_Rustic_Red"]/label</xpath>
-                    <value>
-                        <label>Comfy red bed</label>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Bed_Rustic_Green"]/label</xpath>
-                    <value>
-                        <label>Comfy green bed</label>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Bed_Rustic_Blue"]/label</xpath>
-                    <value>
-                        <label>Comfy blue bed</label>
-                    </value>
-                </Operation>
-
-
-
-
-
-
-
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Bed_RusticDouble_Red"]/label</xpath>
-                    <value>
-                        <label>Comfy red double bed</label>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Bed_RusticDouble_Green"]/label</xpath>
-                    <value>
-                        <label>Comfy green double bed</label>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_Bed_RusticDouble_Blue"]/label</xpath>
-                    <value>
-                        <label>Comfy blue double bed</label>
-                    </value>
-                </Operation>
-
-
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_HideTentWall"]/label</xpath>
-                    <value>
-                        <label>patchwall</label>
-                    </value>
-                </Operation>
-
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_RusticTorchLamp"]/label</xpath>
-                    <value>
-                        <label>standing torch</label>
-                    </value>
-                </Operation>
-
-<!-- FUCK THESE DROPDOWNS -->
-                <Operation Class="PatchOperationRemove">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_BeveragesGroup"]/designatorDropdown</xpath>
-                </Operation>
-
-                <Operation Class="PatchOperationRemove">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_ResearchToolsGroup"]/designatorDropdown</xpath>
-                </Operation>
-
-                <Operation Class="PatchOperationRemove">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_ScribeToolsGroup"]/designatorDropdown</xpath>
-                </Operation>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- RESEARCH MERGING -->
-
-                <Operation Class="PatchOperationFindMod">
-                  <mods>
-                    <li>Vanilla Furniture Expanded</li>
-                  </mods>
-                  <match Class="PatchOperationSequence">
-                    <operations>
-                    <!-- ROYAL FURNITURE -->
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalArmchair"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalDresser"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalEndTable"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTudorBed"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalArmchair"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalCloset"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalThrone"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>MF_RoyalFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationRemove">
-                            <success>Always</success>
-                            <xpath>Defs/ResearchProjectDef[defName="DankPyon_RoyalRusticFurniture"]</xpath>
-                        </li>
-                    <!-- BASIC FURNITURE/RUSTIC FURNITURE -->
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="Bed_Simple"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>DankPyon_RusticFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="Seat_Bench"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>DankPyon_RusticFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="Table_1x1c"]/researchPrerequisites</xpath>
-                            <value>
-                              <researchPrerequisites><li>DankPyon_RusticFurniture</li></researchPrerequisites>
-                            </value>
-                        </li>  
-                        <li Class="PatchOperationRemove">
-                            <success>Always</success>
-                            <xpath>Defs/ResearchProjectDef[defName="MF_BasicFurniture"]</xpath>
-                        </li>
-                    </operations>
-                  </match>
-                </Operation>
-
-
-
-<!-- VFE ARCHITECT -->
-                <Operation Class="PatchOperationFindMod">
-                  <mods>
-                    <li>Vanilla Furniture Expanded - Architect</li>
-                  </mods>
-                  <match Class="PatchOperationSequence">
-                    <operations>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="VFEArch_LogWall"]/designationCategory</xpath>
-                            <value>
-                              <designationCategory></designationCategory>
-                            </value>
-                        </li>
-                    </operations>
-                  </match>
-                </Operation>
-
-
-
-
-
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[@Name="DankPyon_PlaceableFurnitureOnTopOfTables"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Misc</designationCategory>
-                    </value>
-                </Operation>
-
-                <Operation Class="PatchOperationReplace">
-                    <success>Always</success>
-                    <xpath>Defs/ThingDef[defName="DankPyon_WallBanner1x2c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- FEEDDANOOB'S ERROR REMOVALS -->
-
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[@Name="BasicBedBase"]</xpath>
+		<value>
+			<costList>
+				<Cloth>40</Cloth>
+			</costList>
+		</value>
+	</Operation>
+	<!-- REORGANIZE AND HIDE -->
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticDresser"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticDresser"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticDresser"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticDresser"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticDresser"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticDresser"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticDoor"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticDoor"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticDoor"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_SignBase"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_BarrelWater"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_BarrelWater"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_BarrelWater"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_BannerBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BannerBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BannerBase"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticRoomDivider1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticRoomDivider1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticRoomDivider1x2c"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable1x1c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable1x1c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable1x1c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x1c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x1c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x1c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable1x2c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable1x2c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable2x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable2x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTable2x2c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable2x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable2x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedRusticTable2x2c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_Table2x4c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_Table2x4c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_Table2x4c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedTable2x4c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedTable2x4c"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_ReinforcedTable2x4c"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticChair"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticChair"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticChair"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_TableGatherSpotBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_TableGatherSpotBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_TableGatherSpotBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_BedWithQualityBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BedWithQualityBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BedWithQualityBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_BasicBedBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BasicBedBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BasicBedBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableFurnitureBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]/label</xpath>
+		<value>
+			<label>royal research shelf</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_RusticBookshelf"]/label</xpath>
+		<value>
+			<label>research shelf</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableBedBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableBedBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_ArtableBedBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_Lecturn"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_Lecturn"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_Lecturn"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticBookshelf"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticBookshelf"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticBookshelf"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticBookshelf1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticBookshelf1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticBookshelf1x2c"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_RusticBookshelf1x2c"]/label</xpath>
+		<value>
+			<label>large research shelf</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalCloset"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalCloset"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalCloset"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticCloset1x2c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticTallEndTable"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTallEndTable"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTallEndTable"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticEndTable"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticEndTable"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticEndTable"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalTudorBed"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalTudorBed"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalTudorBed"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_WoodBurningStove"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WoodBurningStove"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Temperature</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WoodBurningStove"]</xpath>
+			<value>
+				<designationCategory>Temperature</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticHearth"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticHearth"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Temperature</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticHearth"]</xpath>
+			<value>
+				<designationCategory>Temperature</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_MarketTent_1c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_MarketTent_1c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_MarketTent_1c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_FurnitureWithQualityBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_FurnitureWithQualityBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_FurnitureWithQualityBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticChest"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticChest"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticChest"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_MetalStrongbox"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_MetalStrongbox"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_MetalStrongbox"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalChest"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalChest"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalChest"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_WallTorch"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WallTorch"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WallTorch"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_WallLamp"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WallLamp"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WallLamp"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_LampPost"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_LampPost"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_LampPost"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_CandleStand"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_CandleStand"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_CandleStand"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticLamp"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticLamp"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticLamp"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticTorchLamp"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTorchLamp"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticTorchLamp"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_BuildingBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BuildingBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_BuildingBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_TableBase"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_TableBase"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_TableBase"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticEmptyShelf1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticEmptyShelf1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticEmptyShelf1x2c"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticEmptyShelf"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticEmptyShelf"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticEmptyShelf"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RusticStool"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticStool"]/designationCategory</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RusticStool"]</xpath>
+			<value>
+				<designationCategory IsNull="True"/>
+			</value>
+		</nomatch>
+	</Operation>
+    <Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalThrone"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalThrone"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_RoyalThrone"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<!-- RENAME SHIT -->
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_Bed_Rustic_Red"]/label</xpath>
+		<value>
+			<label>Comfy red bed</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_Bed_Rustic_Green"]/label</xpath>
+		<value>
+			<label>Comfy green bed</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_Bed_Rustic_Blue"]/label</xpath>
+		<value>
+			<label>Comfy blue bed</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_Bed_RusticDouble_Red"]/label</xpath>
+		<value>
+			<label>Comfy red double bed</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_Bed_RusticDouble_Green"]/label</xpath>
+		<value>
+			<label>Comfy green double bed</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_Bed_RusticDouble_Blue"]/label</xpath>
+		<value>
+			<label>Comfy blue double bed</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_HideTentWall"]/label</xpath>
+		<value>
+			<label>patchwall</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DankPyon_RusticTorchLamp"]/label</xpath>
+		<value>
+			<label>standing torch</label>
+		</value>
+	</Operation>
+	<!-- FUCK THESE DROPDOWNS -->
+	<Operation Class="PatchOperationRemove">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[@Name="DankPyon_BeveragesGroup"]/designatorDropdown</xpath>
+	</Operation>
+	<Operation Class="PatchOperationRemove">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[@Name="DankPyon_ResearchToolsGroup"]/designatorDropdown</xpath>
+	</Operation>
+	<Operation Class="PatchOperationRemove">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[@Name="DankPyon_ScribeToolsGroup"]/designatorDropdown</xpath>
+	</Operation>
+	<!-- ROYAL ARMCHAIR NOW WITH GOLD -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalArmchair"]</xpath>
+		<value>
+			<costList>
+				<Gold>30</Gold>
+			</costList>
+		</value>
+	</Operation>
+	<!-- ROYAL THRONE BALANCE PASS -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalThrone"]/costStuffCount</xpath>
+		<value>
+			<costStuffCount>100</costStuffCount>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName="DankPyon_RoyalThrone"]</xpath>
+		<value>
+			<costList>
+				<Gold>25</Gold>
+				<DankPyon_Silk>50</DankPyon_Silk>
+			</costList>
+		</value>
+	</Operation>
+	<!-- RESEARCH MERGING -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Furniture Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ROYAL FURNITURE -->
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalArmchair"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalDresser"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalEndTable"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTudorBed"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalArmchair"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalBookshelf"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalCloset"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalThrone"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>MF_RoyalFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<success>Always</success>
+					<xpath>Defs/ResearchProjectDef[defName="DankPyon_RoyalRusticFurniture"]</xpath>
+				</li>
+				<!-- BASIC FURNITURE/RUSTIC FURNITURE -->
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="Bed_Simple"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>DankPyon_RusticFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="Seat_Bench"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>DankPyon_RusticFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="Table_1x1c"]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>DankPyon_RusticFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<success>Always</success>
+					<xpath>Defs/ResearchProjectDef[defName="MF_BasicFurniture"]</xpath>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	<!-- VFE ARCHITECT -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Furniture Expanded - Architect</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[defName="VFEArch_LogWall"]/designationCategory</xpath>
+					<match Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="VFEArch_LogWall"]/designationCategory</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</match>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[defName="VFEArch_LogWall"]</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</nomatch>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[@Name="DankPyon_PlaceableFurnitureOnTopOfTables"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_PlaceableFurnitureOnTopOfTables"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[@Name="DankPyon_PlaceableFurnitureOnTopOfTables"]</xpath>
+			<value>
+				<designationCategory>Misc</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="DankPyon_WallBanner1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WallBanner1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="DankPyon_WallBanner1x2c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<!-- FEEDDANOOB'S ERROR REMOVALS -->
 	<Operation Class="PatchOperationSequence">
 		<operations>
 			<li Class="PatchOperationConditional" MayRequire="DankPyon.Medieval.Overhaul,vanillaexpanded.vfecore">
@@ -952,332 +1361,212 @@
 			</li>
 		</operations>
 	</Operation>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- RUSTIC STYLE -->
-
-
-                <Operation Class="PatchOperationFindMod">
-                  <mods>
-                    <li>Vanilla Furniture Expanded</li>
-                  </mods>
-                  <match Class="PatchOperationSequence">
-                    <operations>
-                      <li Class="PatchOperationConditional">
-                        <success>Always</success>
-                        <xpath>/Defs/StyleCategoryDef[defName = "Ferny_OldWorld"]/thingDefStyles</xpath>
-                        <match Class="PatchOperationAdd">
-                          <success>Always</success>
-                          <xpath>/Defs/StyleCategoryDef[defName = "Ferny_OldWorld"]/thingDefStyles</xpath>
-                          <value>
-                            <li>
-                              <thingDef>Table_1x1c</thingDef>
-                              <styleDef>FernyRustic_Table1x1c</styleDef>
-                            </li>
-                          </value>
-                        </match>
-                      </li>
-                    </operations>
-                  </match>
-                </Operation>
-
-
-
-
-
-
-
-
-                <Operation Class="PatchOperationConditional">
-                    <success>Always</success>
-                    <xpath>/Defs/ThingDef[defName = "EndTable"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
-                    <nomatch Class="PatchOperationConditional">
-                        <success>Always</success>
-                        <xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
-                        <nomatch Class="PatchOperationAdd">
-                            <success>Always</success>
-                            <xpath>/Defs/ThingDef[defName = "EndTable"]</xpath>
-                            <value>
-                                <comps>
-                                    <li Class="CompProperties_Styleable" />
-                                </comps>
-                            </value>
-                        </nomatch>
-                        <match Class="PatchOperationAdd">
-                            <success>Always</success>
-                            <xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
-                            <value>
-                                <li Class="CompProperties_Styleable" />
-                            </value>
-                        </match>
-                    </nomatch>
-                </Operation>
-
-
-
-
-
-                <Operation Class="PatchOperationConditional">
-                    <success>Always</success>
-                    <xpath>/Defs/ThingDef[defName = "Dresser"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
-                    <nomatch Class="PatchOperationConditional">
-                        <success>Always</success>
-                        <xpath>/Defs/ThingDef[defName = "Dresser"]/comps</xpath>
-                        <nomatch Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName = "Dresser"]</xpath>
-                            <value>
-                                <comps>
-                                    <li Class="CompProperties_Styleable" />
-                                </comps>
-                            </value>
-                        </nomatch>
-                        <match Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName = "Dresser"]/comps</xpath>
-                            <value>
-                                <li Class="CompProperties_Styleable" />
-                            </value>
-                        </match>
-                    </nomatch>
-                </Operation>
-
-
-                <Operation Class="PatchOperationConditional">
-                    <success>Always</success>
-                    <xpath>/Defs/ThingDef[defName = "Door"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
-                    <nomatch Class="PatchOperationConditional">
-                        <success>Always</success>
-                        <xpath>/Defs/ThingDef[defName = "Door"]/comps</xpath>
-                        <nomatch Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName = "Door"]</xpath>
-                            <value>
-                                <comps>
-                                    <li Class="CompProperties_Styleable" />
-                                </comps>
-                            </value>
-                        </nomatch>
-                        <match Class="PatchOperationAdd">
-                            <xpath>/Defs/ThingDef[defName = "Door"]/comps</xpath>
-                            <value>
-                                <li Class="CompProperties_Styleable" />
-                            </value>
-                        </match>
-                    </nomatch>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                  <success>Always</success>
-                  <xpath>Defs/StyleCategoryDef[defName="Ferny_OldWorld"]/thingDefStyles</xpath>
-                  <value>
-                    <li>
-                        <thingDef>Table1x1c</thingDef>
-                        <styleDef>FernyRustic_Table1x1c</styleDef>
-                    </li>
-                    <li>
-                        <thingDef>Table2x4c</thingDef>
-                        <styleDef>FernyRustic_Table2x4c</styleDef>
-                    </li>
-                    <li>
-                        <thingDef>TorchLamp</thingDef>
-                        <styleDef>FernyRustic_Torch</styleDef>
-                    </li>
-                    <li>
-                        <thingDef>Stool</thingDef>
-                        <styleDef>FernyRustic_Stool</styleDef>
-                    </li>
-                    <li>
-                        <thingDef>DiningChair</thingDef>
-                        <styleDef>FernyRustic_DiningChair</styleDef>
-                    </li>
-                    <li>
-                        <thingDef>EndTable</thingDef>
-                        <styleDef>FernyRustic_EndTable</styleDef>
-                    </li>
-                    <li>
-                        <thingDef>Door</thingDef>
-                        <styleDef>FernyDankPyon_RusticDoor</styleDef>
-                    </li>
-                    <li>
-                        <thingDef>Dresser</thingDef>
-                        <styleDef>FernyDankPyon_RusticDresser</styleDef>
-                    </li>
-                  </value>
-                </Operation>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- VFE EMPIRE -->
-                <Operation Class="PatchOperationFindMod">
-                  <mods>
-                    <li>Vanilla Factions Expanded - Empire</li>
-                  </mods>
-                  <match Class="PatchOperationSequence">
-                    <operations>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="VFEE_Candelabra"]/label</xpath>
-                            <value>
-                              <label>electric candelabra</label>
-                            </value>
-                        </li>
-                    </operations>
-                  </match>
-                </Operation>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<!-- VFE MEDIEVAL 2 -->
-                <Operation Class="PatchOperationFindMod">
-                  <mods>
-                    <li>Vanilla Factions Expanded - Medieval 2</li>
-                  </mods>
-                  <match Class="PatchOperationSequence">
-                    <operations>
-                        <li Class="PatchOperationAdd">
-                            <xpath>/Defs</xpath>
-                            <value>
-                            <ReplaceLib.ReplacerDef>
-                                <defName>MedievalOverhaul_Aesthetics_VFEMedieval2</defName>
-                                <replacers>
-                                    <li>
-                                        <replace>VFEM2_CastleWall</replace>
-                                        <with>DankPyon_CastleWall</with>
-                                    </li>
-                                    <li>
-                                        <replace>DankPyon_BedFur</replace>
-                                        <with>VFEM2_FurBed</with>
-                                    </li>
-                                    <li>
-                                        <replace>DankPyon_BedFurDouble</replace>
-                                        <with>VFEM2_DoubleFurBed</with>
-                                    </li>
-                                </replacers>
-                            </ReplaceLib.ReplacerDef>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="VFEM2_LowCastleWall"]/designationCategory</xpath>
-                            <value>
-                              <designationCategory></designationCategory>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_TentWall"]/label</xpath>
-                            <value>
-                              <label>pressed cloth wall</label>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="DankPyon_TentWall"]/costStuffCount</xpath>
-                            <value>
-                              <costStuffCount>10</costStuffCount>
-                            </value>
-                        </li>
-                    </operations>
-                  </match>
-                </Operation>
-
-
-
-
-
-
-
-<!-- VE FURNITURE -->
-                <Operation Class="PatchOperationFindMod">
-                  <mods>
-                    <li>Vanilla Furniture Expanded</li>
-                  </mods>
-                  <match Class="PatchOperationSequence">
-                    <operations>
-                        <li Class="PatchOperationReplace">
-                            <success>Always</success>
-                            <xpath>Defs/ThingDef[defName="Bed_Simple"]/designationCategory</xpath>
-                            <value>
-                              <designationCategory></designationCategory>
-                            </value>
-                        </li>
-                    </operations>
-                  </match>
-                </Operation>
-
-
-
-
+	<!-- RUSTIC STYLE -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Furniture Expanded</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationConditional">
+					<success>Always</success>
+					<xpath>/Defs/StyleCategoryDef[defName = "Ferny_OldWorld"]/thingDefStyles</xpath>
+					<match Class="PatchOperationAdd">
+						<success>Always</success>
+						<xpath>/Defs/StyleCategoryDef[defName = "Ferny_OldWorld"]/thingDefStyles</xpath>
+						<value>
+							<li>
+								<thingDef>Table_1x1c</thingDef>
+								<styleDef>FernyRustic_Table1x1c</styleDef>
+							</li>
+						</value>
+					</match>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[defName = "EndTable"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
+			<xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<success>Always</success>
+				<xpath>/Defs/ThingDef[defName = "EndTable"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<success>Always</success>
+				<xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[defName = "Dresser"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
+			<xpath>/Defs/ThingDef[defName = "Dresser"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Dresser"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Dresser"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[defName = "Door"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
+			<xpath>/Defs/ThingDef[defName = "Door"]/comps</xpath>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Door"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Door"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/StyleCategoryDef[defName="Ferny_OldWorld"]/thingDefStyles</xpath>
+		<value>
+			<li>
+				<thingDef>Table_1x1c</thingDef>
+				<styleDef>FernyRustic_Table1x1c</styleDef>
+			</li>
+			<li>
+				<thingDef>Table2x4c</thingDef>
+				<styleDef>FernyRustic_Table2x4c</styleDef>
+			</li>
+			<li>
+				<thingDef>TorchLamp</thingDef>
+				<styleDef>FernyRustic_Torch</styleDef>
+			</li>
+			<li>
+				<thingDef>Stool</thingDef>
+				<styleDef>FernyRustic_Stool</styleDef>
+			</li>
+			<li>
+				<thingDef>DiningChair</thingDef>
+				<styleDef>FernyRustic_DiningChair</styleDef>
+			</li>
+			<li>
+				<thingDef>EndTable</thingDef>
+				<styleDef>FernyRustic_EndTable</styleDef>
+			</li>
+			<li>
+				<thingDef>Door</thingDef>
+				<styleDef>FernyDankPyon_RusticDoor</styleDef>
+			</li>
+			<li>
+				<thingDef>Dresser</thingDef>
+				<styleDef>FernyDankPyon_RusticDresser</styleDef>
+			</li>
+		</value>
+	</Operation>
+	<!-- VFE EMPIRE -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Empire</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VFEE_Candelabra"]/label</xpath>
+					<value>
+						<label>electric candelabra</label>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	<!-- VFE MEDIEVAL 2 -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Medieval 2</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>/Defs</xpath>
+					<value>
+						<ReplaceLib.ReplacerDef>
+							<defName>MedievalOverhaul_Aesthetics_VFEMedieval2</defName>
+							<replacers>
+								<li>
+									<replace>VFEM2_CastleWall</replace>
+									<with>DankPyon_CastleWall</with>
+								</li>
+								<li>
+									<replace>DankPyon_BedFur</replace>
+									<with>VFEM2_FurBed</with>
+								</li>
+								<li>
+									<replace>DankPyon_BedFurDouble</replace>
+									<with>VFEM2_DoubleFurBed</with>
+								</li>
+							</replacers>
+						</ReplaceLib.ReplacerDef>
+					</value>
+				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[defName="VFEM2_LowCastleWall"]/designationCategory</xpath>
+					<match Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="VFEM2_LowCastleWall"]/designationCategory</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</match>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[defName="VFEM2_LowCastleWall"]</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</nomatch>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_TentWall"]/label</xpath>
+					<value>
+						<label>pressed cloth wall</label>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="DankPyon_TentWall"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>10</costStuffCount>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
 </Patch>

--- a/Mods and Shit/VE Furniture/Patches/ve furniture patch.xml
+++ b/Mods and Shit/VE Furniture/Patches/ve furniture patch.xml
@@ -1,274 +1,477 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<Patch>              
-<!-- PATCHES -->
-                <Operation Class="PatchOperationRemove">
-                    <xpath>Defs/DesignationCategoryDef[defName="AOMorefurniture"]</xpath>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Bed_StoneSlab"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Bed_Simple"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Seat_Cushion"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Bed_Ergonomic"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Bed_DoubleErgonomic"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Bed_DoubleErgonomic"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Bed_Kingsize"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Table_1x1c"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Table_Counter"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Table_LightEndTable"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Table_RoyalEndTable"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Table_RoyalDresser"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Table_Wardrobe"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[defName="Table_Royal1x1c"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[defName="Table_Royal2x2c"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[defName="Table_Royal1x2c"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[defName="Table_Royal3x3c"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationAdd">
-                    <xpath>Defs/ThingDef[defName="Table_Royal2x4c"]</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Light_Streetlamp"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Seat_Bench"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Seat_SquareChair"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory></designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Shelf_WeaponRack"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Seat_ModernChair"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Seat_RoyalChair"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Seat_RoyalArmchair"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[@Name="RoyalTableDesc"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Furniture</designationCategory>
-                    </value>
-                </Operation>
-
-
-
-
-
-                <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ResearchProjectDef[defName="MF_RoyalFurniture"]/label</xpath>
-                    <value>
-                        <label>Royal furniture</label>
-                    </value>
-                </Operation>
-
-
-                <Operation Class="PatchOperationFindMod">
-                  <mods>
-                    <li>Medieval Overhaul</li>
-                  </mods>
-                  <match Class="PatchOperationSequence">
-                    <operations>
-                    <!-- ROYAL FURNITURE -->
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="Seat_RoyalArmchair"]/designationCategory</xpath>
-                            <value>
-                              <designationCategory></designationCategory>
-                            </value>
-                        </li>
-
-
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/label</xpath>
-                            <value>
-                              <label>supreme table (2x2)</label>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/label</xpath>
-                            <value>
-                              <label>supreme table (2x4)</label>
-                            </value>
-                        </li>
-                        <!-- Supreme 2x2 -->
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/label</xpath>
-                            <value>
-                              <label>supreme table (2x2)</label>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationAdd">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]</xpath>
-                            <value>
-                              <description>A ridiculously deluxe table superior to the standard royal fare. A table for only the truest of nobility.</description>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/costStuffCount</xpath>
-                            <value>
-                              <costStuffCount>110</costStuffCount>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/statBases/Beauty</xpath>
-                            <value>
-                              <Beauty>70</Beauty>
-                            </value>
-                        </li>
-                        <!-- Supreme 2x4 -->
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/label</xpath>
-                            <value>
-                              <label>supreme table (2x4)</label>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationAdd">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]</xpath>
-                            <value>
-                              <description>A ridiculously deluxe table superior to the standard royal fare. A table for only the truest of nobility.</description>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/costStuffCount</xpath>
-                            <value>
-                              <costStuffCount>200</costStuffCount>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/statBases/Beauty</xpath>
-                            <value>
-                              <Beauty>90</Beauty>
-                            </value>
-                        </li>
-                        <!-- <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="Table_Royal2x2c"]/designationCategory</xpath>
-                            <value>
-                              <designationCategory></designationCategory>
-                            </value>
-                        </li>
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="Table_Royal2x4c"]/designationCategory</xpath>
-                            <value>
-                              <designationCategory></designationCategory>
-                            </value>
-                        </li> -->
-                        <li Class="PatchOperationReplace">
-                            <xpath>Defs/ThingDef[defName="Table_RoyalEndTable"]/designationCategory</xpath>
-                            <value>
-                              <designationCategory></designationCategory>
-                            </value>
-                        </li>
-                    </operations>
-                  </match>
-                </Operation>
+<?xml version='1.0' encoding='UTF-8'?>
+<Patch>
+	<!-- PATCHES -->
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/DesignationCategoryDef[defName="AOMorefurniture"]</xpath>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[designationCategory="AOMorefurniture"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Furniture</designationCategory>
+					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>/Defs/DesignationCategoryDef[defName="AOMorefurniture"]</xpath>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Bed_StoneSlab"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Bed_StoneSlab"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Bed_StoneSlab"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>	
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="VFE_Bed_StoneSlabDouble"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="VFE_Bed_StoneSlabDouble"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFE_Bed_StoneSlabDouble"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Bed_Simple"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Bed_Simple"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Bed_Simple"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="VFE_Bed_SimpleDouble"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="VFE_Bed_SimpleDouble"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="VFE_Bed_SimpleDouble"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Seat_Cushion"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Seat_Cushion"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Seat_Cushion"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Bed_Ergonomic"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Bed_Ergonomic"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Bed_Ergonomic"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Bed_DoubleErgonomic"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Bed_DoubleErgonomic"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Bed_DoubleErgonomic"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Bed_Kingsize"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Bed_Kingsize"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Bed_Kingsize"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_1x1c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_1x1c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_1x1c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_Counter"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_Counter"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_Counter"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_RoyalEndTable"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_RoyalEndTable"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_RoyalEndTable"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_RoyalDresser"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_RoyalDresser"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_RoyalDresser"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_Wardrobe"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_Wardrobe"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_Wardrobe"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_Royal1x1c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_Royal1x1c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_Royal1x1c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_Royal2x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_Royal2x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_Royal2x2c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_Royal1x2c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_Royal1x2c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_Royal1x2c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_Royal3x3c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_Royal3x3c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_Royal3x3c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Table_Royal2x4c"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Table_Royal2x4c"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Table_Royal2x4c"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>	
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Seat_Bench"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Seat_Bench"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Seat_Bench"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Shelf_WeaponRack"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Shelf_WeaponRack"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Shelf_WeaponRack"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Seat_ModernChair"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Seat_ModernChair"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Seat_ModernChair"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Seat_RoyalChair"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Seat_RoyalChair"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Seat_RoyalChair"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/ThingDef[defName="Seat_RoyalArmchair"]/designationCategory</xpath>
+		<match Class="PatchOperationReplace">
+			<xpath>/Defs/ThingDef[defName="Seat_RoyalArmchair"]/designationCategory</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>/Defs/ThingDef[defName="Seat_RoyalArmchair"]</xpath>
+			<value>
+				<designationCategory>Furniture</designationCategory>
+			</value>
+		</nomatch>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ResearchProjectDef[defName="MF_RoyalFurniture"]/label</xpath>
+		<value>
+			<label>Royal furniture</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Medieval Overhaul</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- ROYAL FURNITURE -->
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[defName="Seat_RoyalArmchair"]/designationCategory</xpath>
+					<match Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="Seat_RoyalArmchair"]/designationCategory</xpath>
+						<value>
+							<designationCategory/>
+						</value>
+					</match>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[defName="Seat_RoyalArmchair"]</xpath>
+						<value>
+							<designationCategory/>
+						</value>
+					</nomatch>
+				</li>
+				<!-- Supreme 2x2 -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/label</xpath>
+					<value>
+						<label>supreme table (2x2)</label>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]</xpath>
+					<value>
+						<description>A ridiculously deluxe table superior to the standard royal fare. A table for only the truest of nobility.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>110</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x2c"]/statBases/Beauty</xpath>
+					<value>
+						<Beauty>70</Beauty>
+					</value>
+				</li>
+				<!-- Supreme 2x4 -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/label</xpath>
+					<value>
+						<label>supreme table (2x4)</label>
+					</value>
+				</li>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]</xpath>
+					<value>
+						<description>A ridiculously deluxe table superior to the standard royal fare. A table for only the truest of nobility.</description>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/costStuffCount</xpath>
+					<value>
+						<costStuffCount>200</costStuffCount>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="DankPyon_RoyalTable2x4c"]/statBases/Beauty</xpath>
+					<value>
+						<Beauty>90</Beauty>
+					</value>
+				</li>
+				<!-- Disable simple bed -->
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[defName="Bed_Simple"]/designationCategory</xpath>
+					<match Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="Bed_Simple"]/designationCategory</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</match>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[defName="Bed_Simple"]</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</nomatch>
+				</li>
+				<li Class="PatchOperationConditional">
+					<xpath>/Defs/ThingDef[defName="VFE_Bed_SimpleDouble"]/designationCategory</xpath>
+					<match Class="PatchOperationReplace">
+						<xpath>/Defs/ThingDef[defName="VFE_Bed_SimpleDouble"]/designationCategory</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</match>
+					<nomatch Class="PatchOperationAdd">
+						<xpath>/Defs/ThingDef[defName="VFE_Bed_SimpleDouble"]</xpath>
+						<value>
+							<designationCategory IsNull="True"/>
+						</value>
+					</nomatch>
+				</li>
+			</operations>
+		</match>
+	</Operation>
 </Patch>


### PR DESCRIPTION
VE Patches:
- Refactored patches to verify whether or not a designation category needs to be added or replaced
- Fix startup error from removing AOMorefurniture designation category by reassigning items needing it to Furniture instead
- Fix startup error from typo in Table_1x1c patch
- Add new items from VEF 2 update
- Restored school chair since it has new texture and a purpose
- Unpatched lamp end table and streetlight in line with VE's changes to them

MO Patches:
- Refactored patches to verify whether or not a designation category needs to be added or replaced
- Fix startup error by removing DankPyon_CandleStand_Beeswax patch since the item no longer exists
- Gave a gold cost to Royal Armchair to justify the beauty increase compared to the vanilla armchair
- Gave a silk and gold cost to the royal throne to justify the beauty increase compared to the royalty meditation throne