### PR TITLE
Update classname for HiddenDesignatorDefs from VEF for 1.6

### DIFF
--- a/1.6/Mods and Shit/VFE Architect/Defs/VFEArchitect_HiddenDesignatorsDefs.xml
+++ b/1.6/Mods and Shit/VFE Architect/Defs/VFEArchitect_HiddenDesignatorsDefs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Defs>
+	<VEF.Buildings.HiddenDesignatorsDef>
+		<defName>FernyVFEArchitect_HiddenDesignators</defName>
+		<hiddenDesignators>		
+			<li>VFEArch_HedgeWall</li>	
+		</hiddenDesignators>							
+	</VEF.Buildings.HiddenDesignatorsDef>
+</Defs>

--- a/1.6/Mods and Shit/VFE Architect/Defs/VFEArchitect_PropDefs.xml
+++ b/1.6/Mods and Shit/VFE Architect/Defs/VFEArchitect_PropDefs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+	<VFEProps.PropDef>
+		<defName>ferny_vfearchitect1</defName>
+		<category>AP_PropCategory_Walls</category>
+		<priority>1</priority>
+		<prop>VFEArch_HedgeWall</prop>
+		<useMatsInsteadOfSilver>true</useMatsInsteadOfSilver>
+	</VFEProps.PropDef>
+</Defs>

--- a/1.6/Mods and Shit/VFE Architect/Patches/VFEArchitect_Patches.xml
+++ b/1.6/Mods and Shit/VFE Architect/Patches/VFEArchitect_Patches.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>              
+                <Operation Class="PatchOperationReplace">
+                    <success>Always</success>
+                    <xpath>Defs/ThingDef[defName="VFEArch_HedgeWall"]/label</xpath>
+                    <value>
+                        <label>trimmed hedge</label>
+                    </value>
+                </Operation>
+                <Operation Class="PatchOperationReplace">
+                    <success>Always</success>
+                    <xpath>Defs/ThingDef[defName="VFEArch_FineWall"]/label</xpath>
+                    <value>
+                        <label>pretty wall</label>
+                    </value>
+                </Operation>
+</Patch>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -87,4 +87,7 @@
     <li IfModActive="farxmai2.vanillafurnitureexpandedpack">Mods and Shit/VE Furniture Additional Pack</li>
     <li IfModActive="dsp.lun">Mods and Shit/Diner Supplies</li>
   </v1.5>
+  <v1.6>
+    <li IfModActive="vanillaexpanded.vfearchitect">1.6/Mods and Shit/VFE Architect</li>
+  </v1.6>
 </loadFolders>


### PR DESCRIPTION
VanillaFurnitureExpanded.HiddenDesignatorsDef is now VEF.Buildings.HiddenDesignatorsDef

This PR creates a 1.6 version of the VFE:Architect patch that is updated with this change.